### PR TITLE
change amount type to string

### DIFF
--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -174,7 +174,7 @@ func (b *BitGo) UpdateWalletAddress(walletId string, addressOrId string, params 
 
 type SendParams struct {
 	Address string `json:"address" valid:"required"`
-	Amount  int    `json:"amount" valid:"required"`
+	Amount  string `json:"amount" valid:"required"`
 
 	WalletPassphrase string `json:"walletPassphrase" valid:"required"`
 	Prv              string `json:"prv,omitempty"`


### PR DESCRIPTION
Amount with int type has a risk of exceeding size limit.

Further explained in: https://github.com/jazzserve/bitgo/issues/14