### PR TITLE
add forwarder version in generating address

### DIFF
--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -124,10 +124,17 @@ func (b *BitGo) GetWalletTransferBySequenceID(walletId string, sequenceId string
 }
 
 // Create Wallet Address
+type ForwarderVersionType int
+
+const (
+	FORWARDER_VERSION_0 ForwarderVersionType = 0
+	FORWARDER_VERSION_1                      = 1
+)
 
 type AddressParams struct {
-	Chain int    `json:"chain,omitempty"`
-	Label string `json:"label,omitempty"`
+	Chain            int                  `json:"chain,omitempty"`
+	Label            string               `json:"label,omitempty"`
+	ForwarderVersion ForwarderVersionType `json:"forwarderVersion,omitempty"`
 }
 
 func (b *BitGo) CreateWalletAddress(walletId string, params *AddressParams) (address Address, err error) {


### PR DESCRIPTION
Add forwarderVersion in generating address, so that it can create new address without deploying it

doc: https://app.bitgo.com/docs/#operation/v2.wallet.newaddress