### PR TITLE
add valueString in transfer

### DIFF
--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -14,6 +14,7 @@ type Transfer struct {
 	Date          time.Time `json:"date"`
 	Confirmations int       `json:"confirmations"`
 	Value         int       `json:"value"`
+	ValueString   string    `json:"valueString"`
 	BitgoFee      int       `json:"bitgoFee"`
 	Usd           float64   `json:"usd"`
 	UsdRate       float64   `json:"usdRate"`


### PR DESCRIPTION
`value` in `int` type could exceed the limit of 2^64

Adding `valueString` to be safe