### PR TITLE
add transfer type

### DIFF
--- a/wallet-operations-basic.go
+++ b/wallet-operations-basic.go
@@ -13,6 +13,7 @@ type Transfer struct {
 	Height        int       `json:"height"`
 	Date          time.Time `json:"date"`
 	Confirmations int       `json:"confirmations"`
+	Type          string    `json:"type"`
 	Value         int       `json:"value"`
 	ValueString   string    `json:"valueString"`
 	BitgoFee      int       `json:"bitgoFee"`


### PR DESCRIPTION
https://api.bitgo.com/docs/#operation/v2.wallet.gettransfer

<img width="840" alt="image" src="https://user-images.githubusercontent.com/42534654/156292793-f45d6035-2512-4590-965d-2693c7b2e7db.png">
`Type` is a permanent field which will be either "receive" or "send"